### PR TITLE
Fix profile service class name

### DIFF
--- a/src/lib/services/CwProfileService.ts
+++ b/src/lib/services/CwProfileService.ts
@@ -1,11 +1,10 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import CwPermissionLevelTypesRepository from '$lib/repositories/CwPermissionLevelTypesRepository';
 import type { Tables } from '$lib/types/supabaseSchema';
 import CwProfileRepository from '$lib/repositories/CwProfilesRepository';
 
 type CwProfile = Tables<'profiles'>;
 
-class CwPermissionLevelTypesService {
+class CwProfileService {
   private repository: CwProfileRepository;
 
   constructor(client: SupabaseClient) {
@@ -25,4 +24,4 @@ class CwPermissionLevelTypesService {
   }
 }
 
-export default CwPermissionLevelTypesService;
+export default CwProfileService;


### PR DESCRIPTION
## Summary
- fix incorrect class name and export in `CwProfileService`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find prettier-plugin-svelte)*

------
https://chatgpt.com/codex/tasks/task_e_684981ea499c8320ba14f707a88c6d62