### PR TITLE
Add DeviceDataRepository and inject into DeviceDataService

### DIFF
--- a/src/lib/interfaces/IDeviceDataService.ts
+++ b/src/lib/interfaces/IDeviceDataService.ts
@@ -1,5 +1,3 @@
-import type { DeviceType } from '../models/Device';
-
 /**
  * Interface for dynamic device data retrieval based on device type
  */
@@ -7,16 +5,18 @@ export interface IDeviceDataService {
   /**
    * Get the latest data for a device based on its type
    * @param devEui The device EUI
-   * @param deviceType The device type information containing data_table_v2
    */
-  getLatestDeviceData(devEui: string, deviceType: DeviceType): Promise<any>;
+  getLatestDeviceData(devEui: string): Promise<Record<string, unknown> | null>;
   
   /**
    * Get device data within a date range based on device type
    * @param devEui The device EUI
-   * @param deviceType The device type information containing data_table_v2
    * @param startDate The start date
    * @param endDate The end date
    */
-  getDeviceDataByDateRange(devEui: string, startDate: Date, endDate: Date): Promise<any[]>;
+  getDeviceDataByDateRange(
+    devEui: string,
+    startDate: Date,
+    endDate: Date
+  ): Promise<Record<string, unknown>[]>;
 }

--- a/src/lib/repositories/DeviceDataRepository.ts
+++ b/src/lib/repositories/DeviceDataRepository.ts
@@ -1,0 +1,70 @@
+import { inject, injectable } from 'inversify';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { TYPES } from '$lib/server/ioc.types';
+import { ErrorHandlingService } from '../errors/ErrorHandlingService';
+
+/**
+ * Repository for querying dynamic device data tables.
+ */
+@injectable()
+export class DeviceDataRepository {
+  constructor(
+    @inject(TYPES.SupabaseClient) private supabase: SupabaseClient,
+    @inject(TYPES.ErrorHandlingService) private errorHandler: ErrorHandlingService
+  ) {}
+
+  /**
+   * Get the latest row for a device from the specified table.
+   * @param tableName The table to query
+   * @param devEui The device EUI
+   */
+  async findLatestByDeviceEui<T extends Record<string, unknown>>(tableName: string, devEui: string): Promise<T | null> {
+    const { data, error } = await this.supabase
+      .from<T>(tableName)
+      .select('*')
+      .eq('dev_eui', devEui)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    if (error) {
+      this.errorHandler.handleDatabaseError(
+        error,
+        `Error fetching latest data from ${tableName} for device ${devEui}`
+      );
+    }
+
+    return data as T;
+  }
+
+  /**
+   * Get device data within the specified date range from the table.
+   * @param tableName The table to query
+   * @param devEui The device EUI
+   * @param startDate Start of range
+   * @param endDate End of range
+   */
+  async findByDateRange<T extends Record<string, unknown>>(
+    tableName: string,
+    devEui: string,
+    startDate: Date,
+    endDate: Date
+  ): Promise<T[]> {
+    const { data, error } = await this.supabase
+      .from<T>(tableName)
+      .select('*')
+      .eq('dev_eui', devEui)
+      .gte('created_at', startDate.toISOString())
+      .lte('created_at', endDate.toISOString())
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      this.errorHandler.handleDatabaseError(
+        error,
+        `Error fetching data from ${tableName} for device ${devEui}`
+      );
+    }
+
+    return (data as T[]) || [];
+  }
+}

--- a/src/lib/server/ioc.config.ts
+++ b/src/lib/server/ioc.config.ts
@@ -7,13 +7,16 @@ import { TYPES } from './ioc.types';
 
 // Interfaces
 import type { ILocationService } from '../interfaces/ILocationService';
+import type { IDeviceDataService } from '../interfaces/IDeviceDataService';
 
 // Services
 import { LocationService } from '../services/LocationService';
+import { DeviceDataService } from '../services/DeviceDataService';
 import { ErrorHandlingService } from '../errors/ErrorHandlingService';
 
 // Repositories
 import { DeviceRepository } from '../repositories/DeviceRepository';
+import { DeviceDataRepository } from '../repositories/DeviceDataRepository';
 import { LocationRepository } from '../repositories/LocationRepository';
 import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from '$env/static/public';
 
@@ -46,10 +49,14 @@ container.bind<LocationRepository>(LocationRepository).toSelf().inSingletonScope
 container.bind<LocationRepository>(TYPES.LocationRepository).to(LocationRepository).inSingletonScope();
 container.bind<DeviceRepository>(DeviceRepository).toSelf().inSingletonScope();
 container.bind<DeviceRepository>(TYPES.DeviceRepository).to(DeviceRepository).inSingletonScope();
+container.bind<DeviceDataRepository>(DeviceDataRepository).toSelf().inSingletonScope();
+container.bind<DeviceDataRepository>(TYPES.DeviceDataRepository).to(DeviceDataRepository).inSingletonScope();
 
 // Bind services
 container.bind<LocationService>(LocationService).toSelf().inSingletonScope();
 container.bind<ILocationService>(TYPES.LocationService).to(LocationService).inSingletonScope();
+container.bind<DeviceDataService>(DeviceDataService).toSelf().inSingletonScope();
+container.bind<IDeviceDataService>(TYPES.DeviceDataService).to(DeviceDataService).inSingletonScope();
 
 // Other services and repositories can be added back as needed
 

--- a/src/lib/server/ioc.types.ts
+++ b/src/lib/server/ioc.types.ts
@@ -11,6 +11,7 @@ export const TYPES = {
   DeviceRepository: Symbol.for('DeviceRepository'),
   DeviceOwnersRepository: Symbol.for('DeviceOwnersRepository'),
   AirDataRepository: Symbol.for('AirDataRepository'),
+  DeviceDataRepository: Symbol.for('DeviceDataRepository'),
   LocationRepository: Symbol.for('LocationRepository'),
   RuleRepository: Symbol.for('RuleRepository'),
   

--- a/src/lib/services/DeviceDataService.ts
+++ b/src/lib/services/DeviceDataService.ts
@@ -1,40 +1,27 @@
 import moment from 'moment';
 import type { IDeviceDataService } from '../interfaces/IDeviceDataService';
-import type { DeviceType } from '../models/Device';
-import type { SupabaseClient } from '@supabase/supabase-js';
+import { injectable, inject } from 'inversify';
+import { TYPES } from '$lib/server/ioc.types';
+import { DeviceRepository } from '../repositories/DeviceRepository';
+import { DeviceDataRepository } from '../repositories/DeviceDataRepository';
 
+@injectable()
 export class DeviceDataService implements IDeviceDataService {
+  constructor(
+    @inject(TYPES.DeviceRepository) private readonly deviceRepository: DeviceRepository,
+    @inject(TYPES.DeviceDataRepository) private readonly deviceDataRepository: DeviceDataRepository
+  ) {}
 
-  constructor(private readonly supabase: SupabaseClient) { }
-
-  /**
-   * Get the latest data for a device based on its type, with optimized handling for large tables
-   * @param devEui The device EUI
-   * @param deviceType The device type information containing data_table_v2
-   */
-  public async getLatestDeviceData(devEui: string): Promise<any> {
+  async getLatestDeviceData(devEui: string): Promise<Record<string, unknown> | null> {
     if (!devEui) {
       throw new Error('Device EUI not specified');
     }
 
-    const cw_device = await this.getDeviceAndType(devEui);
-    const tableName = cw_device.cw_device_type.data_table_v2; // Pull out the table name
+    const device = await this.getDeviceAndType(devEui);
+    const tableName = device.cw_device_type.data_table_v2;
 
     try {
-      const { data, error } = await this.supabase
-        .from(tableName)
-        .select()
-        .eq('dev_eui', devEui)
-        .order('created_at', { ascending: false })
-        .limit(1)
-        .single();
-
-      if (error) {
-        console.error(`Error fetching columns for ${tableName}:`, error);
-        throw new Error(`Error fetching columns: ${error.message}`);
-      }
-
-      return data;
+      return await this.deviceDataRepository.findLatestByDeviceEui<Record<string, unknown>>(tableName, devEui);
     } catch (error) {
       console.error(`Error in getLatestDeviceData for ${devEui} in table ${tableName}:`, error);
       if (error instanceof Error && error.message.includes('AbortError')) {
@@ -50,14 +37,11 @@ export class DeviceDataService implements IDeviceDataService {
     }
   }
 
-  /**
-   * Get device data within a date range based on device type
-   * @param devEui The device EUI
-   * @param deviceType The device type information containing data_table_v2
-   * @param startDate The start date
-   * @param endDate The end date
-   */
-  public async getDeviceDataByDateRange(devEui: string, startDate: Date, endDate: Date): Promise<any[]> {
+  async getDeviceDataByDateRange(
+    devEui: string,
+    startDate: Date,
+    endDate: Date
+  ): Promise<Record<string, unknown>[]> {
     if (!devEui) {
       throw new Error('Device EUI not specified');
     }
@@ -68,72 +52,43 @@ export class DeviceDataService implements IDeviceDataService {
       throw new Error('Start date must be before end date');
     }
 
-    const cw_device = await this.getDeviceAndType(devEui);
-    const tableName = cw_device.cw_device_type.data_table_v2; // Pull out the table name
+    const device = await this.getDeviceAndType(devEui);
+    const tableName = device.cw_device_type.data_table_v2;
 
     try {
-
-      // get the number of uploads between the selected start and end dates
       const monthsInRange = moment(endDate).diff(startDate, 'months');
       if (monthsInRange > 3) {
-        // If the range is too large, limit the query to the last 3 months
         throw new Error('Date range too large');
       }
 
-      const { data, error } = await this.supabase
-        .from(tableName)
-        .select('*')
-        .eq('dev_eui', devEui)
-        .gte('created_at', startDate.toISOString())
-        .lte('created_at', endDate.toISOString())
-        .order('created_at', { ascending: false })
-      // .limit(maxDataToReturn);
-
-      return data || [];
+      return await this.deviceDataRepository.findByDateRange<Record<string, unknown>>(
+        tableName,
+        devEui,
+        startDate,
+        endDate
+      );
     } catch (error) {
-      // Handle errors with a generic response
       console.error(`Error in getDeviceDataByDateRange for ${devEui} in table ${tableName}:`, error);
-
       if (error instanceof Error && error.message.includes('AbortError')) {
-        return [{
-          error: 'Data retrieval timed out',
-          partial: true,
-          dev_eui: devEui,
-          created_at: new Date().toISOString(),
-          note: 'This is a placeholder due to query timeout'
-        }];
+        return [
+          {
+            error: 'Data retrieval timed out',
+            partial: true,
+            dev_eui: devEui,
+            created_at: new Date().toISOString(),
+            note: 'This is a placeholder due to query timeout'
+          }
+        ];
       }
-
-      // Re-throw other errors
       throw error;
     }
   }
 
-  /**
-   * Get the latest data for a device based on its type, with optimized handling for large tables
-   * @param devEui The device EUI
-   * @param deviceType The device type information containing data_table_v2
-   */
-  private async getDeviceAndType(devEui: string): Promise<any> {
-    if (!devEui) {
-      throw new Error('Device EUI not specified');
-    }
-
-    const { data: cw_device, error: deviceError } = await this.supabase
-      .from('cw_devices')
-      .select('*, cw_device_type(*)')
-      .eq('dev_eui', devEui)
-      .single();
-
-    if (deviceError) {
-      console.error(`Error fetching device type for ${devEui}:`, deviceError);
-      throw new Error(`Error fetching device type: ${deviceError.message}`);
-    }
-
-    if (!cw_device || !cw_device.cw_device_type.data_table_v2) {
+  private async getDeviceAndType(devEui: string) {
+    const device = await this.deviceRepository.getDeviceWithType(devEui);
+    if (!device || !device.cw_device_type?.data_table_v2) {
       throw new Error('Device type or data table not specified');
     }
-
-    return cw_device;
+    return device;
   }
 }

--- a/src/routes/api/devices/[devEui]/data/+server.ts
+++ b/src/routes/api/devices/[devEui]/data/+server.ts
@@ -1,6 +1,8 @@
 import { error, json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { DeviceDataService } from '$lib/services/DeviceDataService';
+import type { IDeviceDataService } from '$lib/interfaces/IDeviceDataService';
+import { container } from '$lib/server/ioc.config';
+import { TYPES } from '$lib/server/ioc.types';
 import moment from 'moment';
 
 export const GET: RequestHandler = async ({ params, url, locals: { safeGetSession, supabase } }) => {
@@ -33,7 +35,7 @@ export const GET: RequestHandler = async ({ params, url, locals: { safeGetSessio
     endDate = moment(endDate).endOf('day').toDate();
 
     // Get services from the container
-    const deviceDataService = new DeviceDataService(supabase);
+    const deviceDataService = container.get<IDeviceDataService>(TYPES.DeviceDataService);
 
     // First, try to determine if this is an air data or soil data device based on latest data
     let latestData = null;

--- a/src/routes/api/locations/[locationId]/devices/+server.ts
+++ b/src/routes/api/locations/[locationId]/devices/+server.ts
@@ -9,7 +9,7 @@ import { DeviceRepository } from '$lib/repositories/DeviceRepository';
 import { AirDataRepository } from '$lib/repositories/AirDataRepository';
 import { DeviceService } from '$lib/services/DeviceService';
 import { AirDataService } from '$lib/services/AirDataService';
-import { DeviceDataService } from '$lib/services/DeviceDataService';
+import type { IDeviceDataService } from '$lib/interfaces/IDeviceDataService';
 
 export const GET: RequestHandler = async ({ params, locals }) => {
   try {
@@ -29,7 +29,7 @@ export const GET: RequestHandler = async ({ params, locals }) => {
     // Create services with repositories
     const deviceService = new DeviceService(deviceRepo);
     const airDataService = new AirDataService(airDataRepo);
-    const deviceDataService = new DeviceDataService(locals.supabase);
+    const deviceDataService = container.get<IDeviceDataService>(TYPES.DeviceDataService);
 
     // Get devices for this location - now includes device type info directly
     const devices = await deviceService.getDevicesByLocation(locationId);

--- a/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/+page.server.ts
+++ b/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/+page.server.ts
@@ -6,7 +6,7 @@ import { SessionService } from '$lib/services/SessionService';
 import { ErrorHandlingService } from '$lib/errors/ErrorHandlingService';
 import { DeviceRepository } from '$lib/repositories/DeviceRepository';
 import { DeviceService } from '$lib/services/DeviceService';
-import { DeviceDataService } from '$lib/services/DeviceDataService';
+import type { IDeviceDataService } from '$lib/interfaces/IDeviceDataService';
 import { url } from '@layerstack/utils/routing';
 import moment from 'moment';
 
@@ -23,7 +23,7 @@ export const load: PageServerLoad = async ({ url, params, locals: { safeGetSessi
     try {
         // Get the error handler from the container
         const errorHandler = container.get<ErrorHandlingService>(TYPES.ErrorHandlingService);
-        const deviceDataService = await new DeviceDataService(supabase);
+        const deviceDataService = container.get<IDeviceDataService>(TYPES.DeviceDataService);
         const deviceRepository = new DeviceRepository(supabase, errorHandler);
         const deviceService = new DeviceService(deviceRepository);
 


### PR DESCRIPTION
## Summary
- add `DeviceDataRepository` to encapsulate dynamic table queries
- refactor `DeviceDataService` to use repositories via IoC
- update IoC bindings and types
- use container-provided `DeviceDataService` in routes
- adjust `IDeviceDataService` signatures

## Testing
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684985e96b748320b65381c79bb94e27