### PR TITLE
Add user repository and route refactor

### DIFF
--- a/src/lib/models/User.ts
+++ b/src/lib/models/User.ts
@@ -1,0 +1,16 @@
+import type { Database } from '../../../database.types';
+
+/**
+ * Represents a user profile from the database
+ */
+export type User = Database['public']['Tables']['profiles']['Row'];
+
+/**
+ * Data required to insert a new user profile
+ */
+export type UserInsert = Database['public']['Tables']['profiles']['Insert'];
+
+/**
+ * Fields allowed for updating a user profile
+ */
+export type UserUpdate = Database['public']['Tables']['profiles']['Update'];

--- a/src/lib/repositories/UserRepository.ts
+++ b/src/lib/repositories/UserRepository.ts
@@ -1,0 +1,39 @@
+import { inject, injectable } from 'inversify';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { BaseRepository } from './BaseRepository';
+import type { User } from '../models/User';
+import { TYPES } from '$lib/server/ioc.types';
+import { ErrorHandlingService } from '../errors/ErrorHandlingService';
+
+/**
+ * Repository for user profile data access
+ */
+@injectable()
+export class UserRepository extends BaseRepository<User, string> {
+  protected tableName = 'profiles';
+  protected primaryKey = 'id';
+  protected entityName = 'User';
+
+  constructor(
+    @inject(TYPES.SupabaseClient) supabase: SupabaseClient,
+    @inject(TYPES.ErrorHandlingService) errorHandler: ErrorHandlingService
+  ) {
+    super(supabase, errorHandler);
+  }
+
+  /**
+   * Get all users ordered by full name
+   */
+  async findAll(): Promise<User[]> {
+    const { data, error } = await this.supabase
+      .from(this.tableName)
+      .select('id, email, full_name, username')
+      .order('full_name', { ascending: true });
+
+    if (error) {
+      this.errorHandler.handleDatabaseError(error, 'Error finding all users');
+    }
+
+    return (data as User[]) || [];
+  }
+}

--- a/src/lib/server/ioc.config.ts
+++ b/src/lib/server/ioc.config.ts
@@ -15,6 +15,7 @@ import { ErrorHandlingService } from '../errors/ErrorHandlingService';
 import { DeviceRepository } from '../repositories/DeviceRepository';
 import { LocationRepository } from '../repositories/LocationRepository';
 import { NotifierTypeRepository } from '../repositories/NotifierTypeRepository';
+import { UserRepository } from '../repositories/UserRepository';
 import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from '$env/static/public';
 
 // Create and configure the IoC container
@@ -48,6 +49,8 @@ container.bind<DeviceRepository>(DeviceRepository).toSelf().inSingletonScope();
 container.bind<DeviceRepository>(TYPES.DeviceRepository).to(DeviceRepository).inSingletonScope();
 container.bind<NotifierTypeRepository>(NotifierTypeRepository).toSelf().inSingletonScope();
 container.bind<NotifierTypeRepository>(TYPES.NotifierTypeRepository).to(NotifierTypeRepository).inSingletonScope();
+container.bind<UserRepository>(UserRepository).toSelf().inSingletonScope();
+container.bind<UserRepository>(TYPES.UserRepository).to(UserRepository).inSingletonScope();
 
 // Bind services
 container.bind<LocationService>(LocationService).toSelf().inSingletonScope();

--- a/src/lib/server/ioc.types.ts
+++ b/src/lib/server/ioc.types.ts
@@ -14,6 +14,7 @@ export const TYPES = {
   LocationRepository: Symbol.for('LocationRepository'),
   RuleRepository: Symbol.for('RuleRepository'),
   NotifierTypeRepository: Symbol.for('NotifierTypeRepository'),
+  UserRepository: Symbol.for('UserRepository'),
   
   // Services
   DeviceService: Symbol.for('DeviceService'),

--- a/src/routes/api/users/+server.ts
+++ b/src/routes/api/users/+server.ts
@@ -3,14 +3,15 @@ import { container } from '$lib/server/ioc.config';
 import { TYPES } from '$lib/server/ioc.types';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import type { SupabaseClient } from '@supabase/supabase-js';
 import type { IAuthService } from '$lib/interfaces/IAuthService';
+import { UserRepository } from '$lib/repositories/UserRepository';
+import { ErrorHandlingService } from '$lib/errors/ErrorHandlingService';
 
 export const GET: RequestHandler = async () => {
   try {
     // Get services from IoC container
-    const supabase = container.get<SupabaseClient>(TYPES.SupabaseClient);
     const authService = container.get<IAuthService>(TYPES.AuthService);
+    const userRepo = container.get<UserRepository>(TYPES.UserRepository);
 
     // Check if the user is authenticated
     const sessionData = await authService.getSession();
@@ -18,20 +19,13 @@ export const GET: RequestHandler = async () => {
       return json({ error: 'Authentication required' }, { status: 401 });
     }
 
-    // Fetch user profiles from the database
-    const { data, error } = await supabase
-      .from('profiles')
-      .select('id, email, full_name, username')
-      .order('full_name', { ascending: true });
+    // Fetch user profiles using the repository
+    const users = await userRepo.findAll();
 
-    if (error) {
-      console.error('Error fetching users:', error);
-      return json({ error: 'Failed to fetch users' }, { status: 500 });
-    }
-
-    return json(data);
+    return json(users);
   } catch (error) {
-    console.error('Error fetching users:', error);
+    const errorHandler = container.get<ErrorHandlingService>(TYPES.ErrorHandlingService);
+    errorHandler.logError(error as Error);
     return json({ error: 'Failed to fetch users' }, { status: 500 });
   }
 };


### PR DESCRIPTION
## Summary
- define typed `User` model
- implement `UserRepository` for `profiles`
- register the new repository in IoC container
- refactor `/api/users` API to use repository

## Testing
- `pnpm test:unit --run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498d6200bc83209574664a2c30cee0