### PR TITLE
Implement reports management UI

### DIFF
--- a/src/routes/app/all-reports/+page.server.ts
+++ b/src/routes/app/all-reports/+page.server.ts
@@ -1,0 +1,85 @@
+import { redirect, fail } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { SessionService } from '$lib/services/SessionService';
+
+export const load: PageServerLoad = async ({ locals: { supabase } }) => {
+  const sessionService = new SessionService(supabase);
+  const { session, user } = await sessionService.getSafeSession();
+
+  if (!session || !user) {
+    throw redirect(302, '/auth/login');
+  }
+
+  const { data: reports, error } = await supabase
+    .from('reports_templates')
+    .select('*')
+    .eq('owner_id', user.id)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    console.error('Error fetching reports:', error.message);
+  }
+
+  return {
+    reports: reports || [],
+    userId: user.id
+  };
+};
+
+export const actions: Actions = {
+  updateReport: async ({ request, locals: { supabase } }) => {
+    const sessionService = new SessionService(supabase);
+    const { session, user } = await sessionService.getSafeSession();
+    if (!session || !user) {
+      return fail(401, { success: false, error: 'Unauthorized' });
+    }
+
+    const data = await request.formData();
+    const id = Number(data.get('id'));
+    const name = data.get('name') as string;
+
+    if (!id || !name) {
+      return fail(400, { success: false, error: 'Missing id or name' });
+    }
+
+    const { error } = await supabase
+      .from('reports_templates')
+      .update({ name })
+      .eq('id', id)
+      .eq('owner_id', user.id);
+
+    if (error) {
+      console.error('Failed to update report:', error.message);
+      return { success: false, error: 'Failed to update report' };
+    }
+
+    return { success: true };
+  },
+  deleteReport: async ({ request, locals: { supabase } }) => {
+    const sessionService = new SessionService(supabase);
+    const { session, user } = await sessionService.getSafeSession();
+    if (!session || !user) {
+      return fail(401, { success: false, error: 'Unauthorized' });
+    }
+
+    const data = await request.formData();
+    const id = Number(data.get('id'));
+
+    if (!id) {
+      return fail(400, { success: false, error: 'Missing id' });
+    }
+
+    const { error } = await supabase
+      .from('reports_templates')
+      .delete()
+      .eq('id', id)
+      .eq('owner_id', user.id);
+
+    if (error) {
+      console.error('Failed to delete report:', error.message);
+      return { success: false, error: 'Failed to delete report' };
+    }
+
+    return { success: true };
+  }
+};

--- a/src/routes/app/all-reports/+page.svelte
+++ b/src/routes/app/all-reports/+page.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import { success, error as errorToast } from '$lib/stores/toast.svelte';
+
+  let { data } = $props();
+  let reports: any[] = data.reports;
+
+  async function updateReport(report: any) {
+    const formData = new FormData();
+    formData.append('id', String(report.id));
+    formData.append('name', report.name);
+    const res = await fetch('?/updateReport', { method: 'POST', body: formData });
+    const result = await res.json();
+    if (result.success) {
+      success('Report updated');
+    } else {
+      errorToast(result.error || 'Failed to update');
+    }
+  }
+
+  async function deleteReport(id: number) {
+    const formData = new FormData();
+    formData.append('id', String(id));
+    const res = await fetch('?/deleteReport', { method: 'POST', body: formData });
+    const result = await res.json();
+    if (result.success) {
+      reports = reports.filter((r) => r.id !== id);
+      success('Report deleted');
+    } else {
+      errorToast(result.error || 'Failed to delete');
+    }
+  }
+</script>
+
+<div class="p-4 flex flex-col gap-4">
+  <h1 class="text-xl font-semibold">Your Reports</h1>
+  <a href="/app/all-reports/reports/create" class="underline text-primary">Create New Report</a>
+
+  {#if reports.length === 0}
+    <p>No reports found.</p>
+  {:else}
+    <ul class="flex flex-col gap-2">
+      {#each reports as report (report.id)}
+        <li class="border rounded p-2 flex items-center gap-2">
+          <input class="flex-1 border p-1 rounded" bind:value={report.name} />
+          <button class="btn" on:click={() => updateReport(report)}>Save</button>
+          <button class="btn" on:click={() => deleteReport(report.id)}>Delete</button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>

--- a/src/routes/app/all-reports/reports/create/+page.server.ts
+++ b/src/routes/app/all-reports/reports/create/+page.server.ts
@@ -1,0 +1,59 @@
+import { redirect, fail } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { SessionService } from '$lib/services/SessionService';
+
+export const load: PageServerLoad = async ({ locals: { supabase } }) => {
+  const sessionService = new SessionService(supabase);
+  const { session, user } = await sessionService.getSafeSession();
+  if (!session || !user) {
+    throw redirect(302, '/auth/login');
+  }
+  return {};
+};
+
+export const actions: Actions = {
+  createReport: async ({ request, locals: { supabase } }) => {
+    const sessionService = new SessionService(supabase);
+    const { session, user } = await sessionService.getSafeSession();
+    if (!session || !user) {
+      return fail(401, { success: false, error: 'Unauthorized' });
+    }
+
+    const formData = await request.formData();
+    const name = formData.get('name') as string;
+    const values = formData.getAll('values');
+    const colors = formData.getAll('colors');
+    const interval = Number(formData.get('interval'));
+    const averaged = formData.get('averaged') === 'on';
+    const weekly = formData.get('weekly') === 'on';
+    const monthly = formData.get('monthly') === 'on';
+    const recipients = formData.get('recipients') as string;
+
+    if (!name) {
+      return fail(400, { success: false, error: 'Name is required' });
+    }
+
+    const template = {
+      values,
+      colors,
+      interval,
+      averaged,
+      weekly,
+      monthly
+    };
+
+    const { error } = await supabase.from('reports_templates').insert({
+      name,
+      owner_id: user.id,
+      recipients,
+      template
+    });
+
+    if (error) {
+      console.error('Failed to create report:', error.message);
+      return { success: false, error: 'Failed to create report' };
+    }
+
+    return { success: true };
+  }
+};

--- a/src/routes/app/all-reports/reports/create/+page.svelte
+++ b/src/routes/app/all-reports/reports/create/+page.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { success, error as errorToast } from '$lib/stores/toast.svelte';
+
+  async function handleSubmit(event: SubmitEvent) {
+    event.preventDefault();
+    const form = event.currentTarget as HTMLFormElement;
+    const formData = new FormData(form);
+    const res = await fetch('?/createReport', { method: 'POST', body: formData });
+    const result = await res.json();
+    if (result.success) {
+      success('Report created');
+      form.reset();
+    } else {
+      errorToast(result.error || 'Failed to create report');
+    }
+  }
+</script>
+
+<div class="p-4 flex flex-col gap-4">
+  <h1 class="text-xl font-semibold">Create Report</h1>
+  <form on:submit|preventDefault={handleSubmit} class="flex flex-col gap-2">
+    <label>
+      Name
+      <input name="name" class="border p-1 rounded" required />
+    </label>
+    <label>
+      Values (comma separated)
+      <input name="values" class="border p-1 rounded" />
+    </label>
+    <label>
+      Colors (comma separated)
+      <input name="colors" class="border p-1 rounded" />
+    </label>
+    <label>
+      Compression Interval (minutes)
+      <input name="interval" type="number" class="border p-1 rounded" />
+    </label>
+    <label class="flex gap-2">
+      <input type="checkbox" name="averaged" /> Average values
+    </label>
+    <label class="flex gap-2">
+      <input type="checkbox" name="weekly" /> Send weekly
+    </label>
+    <label class="flex gap-2">
+      <input type="checkbox" name="monthly" /> Send monthly
+    </label>
+    <label>
+      Recipients (comma separated emails)
+      <input name="recipients" class="border p-1 rounded" />
+    </label>
+    <button class="btn" type="submit">Create</button>
+  </form>
+</div>


### PR DESCRIPTION
## Summary
- add new All Reports page server logic and UI
- create report creation form
- provide server actions for creating, updating and deleting reports

## Testing
- `npm test` *(fails: playwright not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849bb9342fc83209aafafaaad2f5cf1