### PR TITLE
Add LoRaWAN downlink endpoint and control UI

### DIFF
--- a/SAMPLE.env
+++ b/SAMPLE.env
@@ -1,3 +1,0 @@
-PRIVATE_SUPABASE_URL= # Put your Supabase URL from the Discord Developers channel here!
-PRIVATE_SUPABASE_ANON_KEY= # Put your Anon key from the Discord Developers channel here!
-TTI_API_KEY=

--- a/SAMPLE.env
+++ b/SAMPLE.env
@@ -1,2 +1,3 @@
 PRIVATE_SUPABASE_URL= # Put your Supabase URL from the Discord Developers channel here!
 PRIVATE_SUPABASE_ANON_KEY= # Put your Anon key from the Discord Developers channel here!
+TTI_API_KEY=

--- a/src/lib/lorawan/dragino.ts
+++ b/src/lib/lorawan/dragino.ts
@@ -1,6 +1,6 @@
 export const DRAGINO_LT22222L_PAYLOADS = {
-  relay1On: 'AQE=',
-  relay1Off: 'AQA=',
-  relay2On: 'AgE=',
-  relay2Off: 'AgA='
+  relay1On: 'AwER',   // 030111
+  relay1Off: 'AwAR',  // 030011
+  relay2On: 'AxEB',   // 031101
+  relay2Off: 'AxEA'   // 031100
 };

--- a/src/lib/lorawan/dragino.ts
+++ b/src/lib/lorawan/dragino.ts
@@ -1,0 +1,6 @@
+export const DRAGINO_LT22222L_PAYLOADS = {
+  relay1On: 'AQE=',
+  relay1Off: 'AQA=',
+  relay2On: 'AgE=',
+  relay2Off: 'AgA='
+};

--- a/src/routes/api/devices/[devEui]/downlink/+server.ts
+++ b/src/routes/api/devices/[devEui]/downlink/+server.ts
@@ -52,7 +52,7 @@ export const POST: RequestHandler = async ({ params, request, locals: { supabase
     throw error(500, 'TTI_API_KEY not configured');
   }
 
-  const url = `https://cropwatch.au1.cloud.thethings.industries/api/v3/as/applications/${appId}/devices/${device.dev_eui}/down/replace`;
+  const url = `https://cropwatch.au1.cloud.thethings.industries/api/v3/as/applications/${appId}/devices/${device.tti_name}/down/replace`;
 
   const payload = {
     downlinks: [

--- a/src/routes/api/devices/[devEui]/downlink/+server.ts
+++ b/src/routes/api/devices/[devEui]/downlink/+server.ts
@@ -1,0 +1,84 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { container } from '$lib/server/ioc.config';
+import { TYPES } from '$lib/server/ioc.types';
+import { DeviceRepository } from '$lib/repositories/DeviceRepository';
+import { DeviceService } from '$lib/services/DeviceService';
+import { ErrorHandlingService } from '$lib/errors/ErrorHandlingService';
+import { DRAGINO_LT22222L_PAYLOADS } from '$lib/lorawan/dragino';
+import { env } from '$env/dynamic/private';
+
+export const POST: RequestHandler = async ({ params, request, locals: { supabase, safeGetSession } }) => {
+  const { devEui } = params;
+  const { session, user } = await safeGetSession();
+  if (!session || !user) {
+    throw error(401, 'Authentication required');
+  }
+
+  if (!devEui) {
+    throw error(400, 'Device EUI is required');
+  }
+
+  const errorHandler = container.get<ErrorHandlingService>(TYPES.ErrorHandlingService);
+  const repo = new DeviceRepository(supabase, errorHandler);
+  const deviceService = new DeviceService(repo);
+
+  const device = await deviceService.getDeviceWithTypeByEui(devEui);
+  if (!device) {
+    throw error(404, 'Device not found');
+  }
+
+  const owner = await repo.findDeviceOwner(devEui, user.id);
+  if (!owner) {
+    throw error(403, 'Forbidden');
+  }
+
+  const body = await request.json();
+  const payloadName = body.payloadName as keyof typeof DRAGINO_LT22222L_PAYLOADS | undefined;
+  const frm_payload = body.frm_payload as string | undefined;
+
+  const base64Payload = payloadName ? DRAGINO_LT22222L_PAYLOADS[payloadName] : frm_payload;
+  if (!base64Payload) {
+    throw error(400, 'No payload specified');
+  }
+
+  const appId = device.cw_device_type?.TTI_application_id;
+  if (!appId) {
+    throw error(500, 'Device type missing TTI application id');
+  }
+
+  const apiKey = env.TTI_API_KEY;
+  if (!apiKey) {
+    throw error(500, 'TTI_API_KEY not configured');
+  }
+
+  const url = `https://cropwatch.au1.cloud.thethings.industries/api/v3/as/applications/${appId}/devices/${device.dev_eui}/down/replace`;
+
+  const payload = {
+    downlinks: [
+      {
+        frm_payload: base64Payload,
+        f_port: 2,
+        priority: 'HIGH',
+        confirmed: true
+      }
+    ]
+  };
+
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify(payload)
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    console.error('TTI downlink error', text);
+    throw error(500, 'Failed to send downlink');
+  }
+
+  return json({ success: true });
+};

--- a/src/routes/api/devices/[devEui]/status/+server.ts
+++ b/src/routes/api/devices/[devEui]/status/+server.ts
@@ -1,0 +1,20 @@
+import { json, error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { DeviceDataService } from '$lib/services/DeviceDataService';
+
+export const GET: RequestHandler = async ({ params, locals: { safeGetSession, supabase } }) => {
+  const { devEui } = params;
+  const { session } = await safeGetSession();
+  if (!session) {
+    throw error(401, 'Authentication required');
+  }
+  if (!devEui) {
+    throw error(400, 'Device EUI is required');
+  }
+  const svc = new DeviceDataService(supabase);
+  const latest = await svc.getLatestDeviceData(devEui);
+  if (!latest) {
+    throw error(404, 'No data');
+  }
+  return json(latest);
+};

--- a/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/downlink/+page.server.ts
+++ b/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/downlink/+page.server.ts
@@ -1,0 +1,32 @@
+import { redirect, error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { SessionService } from '$lib/services/SessionService';
+import { container } from '$lib/server/ioc.config';
+import { TYPES } from '$lib/server/ioc.types';
+import { DeviceRepository } from '$lib/repositories/DeviceRepository';
+import { DeviceService } from '$lib/services/DeviceService';
+import { ErrorHandlingService } from '$lib/errors/ErrorHandlingService';
+
+export const load: PageServerLoad = async ({ params, locals: { supabase } }) => {
+  const sessionService = new SessionService(supabase);
+  const sessionResult = await sessionService.getSafeSession();
+  if (!sessionResult || !sessionResult.user) {
+    throw redirect(302, '/auth/login');
+  }
+  const { devEui } = params;
+  const errorHandler = container.get<ErrorHandlingService>(TYPES.ErrorHandlingService);
+  const repo = new DeviceRepository(supabase, errorHandler);
+  const deviceService = new DeviceService(repo);
+
+  const device = await deviceService.getDeviceWithTypeByEui(devEui);
+  if (!device) {
+    throw error(404, 'Device not found');
+  }
+
+  const owner = await repo.findDeviceOwner(devEui, sessionResult.user.id);
+  if (!owner) {
+    throw error(403, 'Forbidden');
+  }
+
+  return { device };
+};

--- a/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/downlink/+page.svelte
+++ b/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/downlink/+page.svelte
@@ -1,62 +1,76 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { success, error as showError } from '$lib/stores/toast.svelte';
-  import { DRAGINO_LT22222L_PAYLOADS } from '$lib/lorawan/dragino';
+	import { onMount } from 'svelte';
+	import { success, error as showError } from '$lib/stores/toast.svelte';
+	import { DRAGINO_LT22222L_PAYLOADS } from '$lib/lorawan/dragino';
 
-  let { data } = $props();
-  const devEui = data.device.dev_eui;
-  let status: any = {};
-  let interval: number;
+	let { data } = $props();
+	const devEui = data.device.dev_eui;
+	let status: any = $state({});
+	let interval: number;
 
-  async function fetchStatus() {
-    try {
-      const res = await fetch(`/api/devices/${devEui}/status`);
-      if (res.ok) {
-        status = await res.json();
-      }
-    } catch (err) {
-      console.error('Status fetch failed', err);
-    }
-  }
+	async function fetchStatus() {
+		try {
+			const res = await fetch(`/api/devices/${devEui}/status`);
+			if (res.ok) {
+				status = await res.json();
+			}
+		} catch (err) {
+			console.error('Status fetch failed', err);
+		}
+	}
 
-  async function send(payloadName: keyof typeof DRAGINO_LT22222L_PAYLOADS) {
-    try {
-      const res = await fetch(`/api/devices/${devEui}/downlink`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ payloadName })
-      });
-      if (res.ok) {
-        success('Downlink sent');
-        await fetchStatus();
-      } else {
-        const txt = await res.text();
-        showError('Downlink failed: ' + txt);
-      }
-    } catch (err) {
-      showError('Downlink failed');
-    }
-  }
+	async function send(payloadName: keyof typeof DRAGINO_LT22222L_PAYLOADS) {
+		try {
+			const res = await fetch(`/api/devices/${devEui}/downlink`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ payloadName })
+			});
+			if (res.ok) {
+				success('Downlink sent');
+				await fetchStatus();
+			} else {
+				const txt = await res.text();
+				showError('Downlink failed: ' + txt);
+			}
+		} catch (err) {
+			showError('Downlink failed');
+		}
+	}
 
-  onMount(() => {
-    fetchStatus();
-    interval = setInterval(fetchStatus, 5000);
-    return () => clearInterval(interval);
-  });
+	onMount(() => {
+		fetchStatus();
+		interval = setInterval(fetchStatus, 5000);
+		return () => clearInterval(interval);
+	});
 </script>
 
-<h1 class="text-xl font-bold mb-4">Device Downlink Control: {devEui}</h1>
-<div class="flex gap-4 mb-6">
-  <button class="btn" on:click={() => send('relay1On')}>Relay 1 ON</button>
-  <button class="btn" on:click={() => send('relay1Off')}>Relay 1 OFF</button>
-  <button class="btn" on:click={() => send('relay2On')}>Relay 2 ON</button>
-  <button class="btn" on:click={() => send('relay2Off')}>Relay 2 OFF</button>
+<h1 class="mb-4 text-xl font-bold">Device Downlink Control: {devEui}</h1>
+<div class="mb-6 flex gap-4">
+	<button class="btn" onclick={() => send('relay1On')}>Relay 1 ON</button>
+	<button class="btn" onclick={() => send('relay1Off')}>Relay 1 OFF</button>
+	<button class="btn" onclick={() => send('relay2On')}>Relay 2 ON</button>
+	<button class="btn" onclick={() => send('relay2Off')}>Relay 2 OFF</button>
 </div>
 
-<pre class="bg-gray-100 p-2 rounded">{JSON.stringify(status, null, 2)}</pre>
+<pre class="rounded bg-gray-100 p-2">{JSON.stringify(status, null, 2)}</pre>
 
 <style>
-  .btn {
-    @apply px-3 py-2 bg-blue-600 text-white rounded shadow;
-  }
+	.btn {
+		padding: 0.5rem 1rem;
+		background-color: #4a90e2;
+		color: white;
+		border: none;
+		border-radius: 0.25rem;
+		cursor: pointer;
+	}
+
+	.btn:hover {
+		background-color: #357abd;
+	}
+
+	pre {
+		overflow-x: auto;
+		white-space: pre-wrap;
+	}
 </style>

--- a/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/downlink/+page.svelte
+++ b/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/downlink/+page.svelte
@@ -38,11 +38,11 @@
 		}
 	}
 
-	onMount(() => {
-		fetchStatus();
-		interval = setInterval(fetchStatus, 5000);
-		return () => clearInterval(interval);
-	});
+	// onMount(() => {
+	// 	fetchStatus();
+	// 	interval = setInterval(fetchStatus, 5000);
+	// 	return () => clearInterval(interval);
+	// });
 </script>
 
 <h1 class="mb-4 text-xl font-bold">Device Downlink Control: {devEui}</h1>

--- a/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/downlink/+page.svelte
+++ b/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/downlink/+page.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { success, error as showError } from '$lib/stores/toast.svelte';
+  import { DRAGINO_LT22222L_PAYLOADS } from '$lib/lorawan/dragino';
+
+  let { data } = $props();
+  const devEui = data.device.dev_eui;
+  let status: any = {};
+  let interval: number;
+
+  async function fetchStatus() {
+    try {
+      const res = await fetch(`/api/devices/${devEui}/status`);
+      if (res.ok) {
+        status = await res.json();
+      }
+    } catch (err) {
+      console.error('Status fetch failed', err);
+    }
+  }
+
+  async function send(payloadName: keyof typeof DRAGINO_LT22222L_PAYLOADS) {
+    try {
+      const res = await fetch(`/api/devices/${devEui}/downlink`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ payloadName })
+      });
+      if (res.ok) {
+        success('Downlink sent');
+        await fetchStatus();
+      } else {
+        const txt = await res.text();
+        showError('Downlink failed: ' + txt);
+      }
+    } catch (err) {
+      showError('Downlink failed');
+    }
+  }
+
+  onMount(() => {
+    fetchStatus();
+    interval = setInterval(fetchStatus, 5000);
+    return () => clearInterval(interval);
+  });
+</script>
+
+<h1 class="text-xl font-bold mb-4">Device Downlink Control: {devEui}</h1>
+<div class="flex gap-4 mb-6">
+  <button class="btn" on:click={() => send('relay1On')}>Relay 1 ON</button>
+  <button class="btn" on:click={() => send('relay1Off')}>Relay 1 OFF</button>
+  <button class="btn" on:click={() => send('relay2On')}>Relay 2 ON</button>
+  <button class="btn" on:click={() => send('relay2Off')}>Relay 2 OFF</button>
+</div>
+
+<pre class="bg-gray-100 p-2 rounded">{JSON.stringify(status, null, 2)}</pre>
+
+<style>
+  .btn {
+    @apply px-3 py-2 bg-blue-600 text-white rounded shadow;
+  }
+</style>


### PR DESCRIPTION
## Summary
- allow storing LoRaWAN API key via `TTI_API_KEY`
- expose preset payloads for Dragino LT-22222-L
- add API endpoint to send downlinks to user-owned devices
- add API endpoint to fetch latest device status
- add UI page for sending relay commands and polling device status

## Testing
- `npm run test:unit -- --run` *(fails: TypeError: template is not a function)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684e482088288320824fd1c17ce619a1