### PR TITLE
Fix UI hang on device details page

### DIFF
--- a/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/device-detail.svelte.ts
+++ b/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/device-detail.svelte.ts
@@ -30,7 +30,7 @@ export function setupDeviceDetail() {
 
 	// Chart data
 	type ChartData = Record<string, number[] | string[]>;
-	const chartData: ChartData = $state({ labels: [] });
+	let chartData: ChartData = $state({ labels: [] });
 
 	// States for the component
 	let loading = $state(false);
@@ -51,8 +51,12 @@ export function setupDeviceDetail() {
 	function processHistoricalData(historicalData: any[]) {
 		if (!historicalData || historicalData.length === 0) return;
 
+		// Placeholder for the chart data: Don’t update the `chartData` state directly in the loops below
+		// because the UI will be unresponsive due to repeated reactivity updates by Svelte.
+		const _chartData: ChartData = { labels: [] };
+
 		// Extract timestamps for chart labels (most recent to oldest)
-		chartData.labels = historicalData
+		_chartData.labels = historicalData
 			.map((data) => formatDateForDisplay(data.created_at))
 			.reverse();
 
@@ -67,7 +71,7 @@ export function setupDeviceDetail() {
 
 		// Reset chartData and stats for all numeric keys
 		numericKeys.forEach((key) => {
-			chartData[key] = [];
+			_chartData[key] = [];
 			stats[key] = { 
 				min: 0, 
 				max: 0, 
@@ -90,7 +94,7 @@ export function setupDeviceDetail() {
 		historicalData.forEach((data) => {
 			numericKeys.forEach((key) => {
 				if (typeof data[key] === 'number' && data[key] !== null) {
-					(chartData[key] as number[]).unshift(data[key]);
+					(_chartData[key] as number[]).unshift(data[key]);
 					valueArrays[key].push(data[key]);
 				}
 			});
@@ -143,6 +147,7 @@ export function setupDeviceDetail() {
 				}
 			}
 		});
+		chartData = _chartData;
 		loading = false;
 	}
 

--- a/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/device-detail.svelte.ts
+++ b/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/device-detail.svelte.ts
@@ -147,6 +147,7 @@ export function setupDeviceDetail() {
 				}
 			}
 		});
+
 		chartData = _chartData;
 		loading = false;
 	}


### PR DESCRIPTION
I could debug the source of the obvious hang on the device details page. It’s annoying for everyone, so let’s fix it quickly.

The problem is that the `chartData` state is updated a lot in `processHistoricalData()`, which causes Svelte’s reactivity updates unnecessarily. This PR fixes the issue by updating the state only once.