### PR TITLE
Refresh Location Details page

### DIFF
--- a/src/lib/repositories/LocationRepository.ts
+++ b/src/lib/repositories/LocationRepository.ts
@@ -154,7 +154,7 @@ export class LocationRepository extends BaseRepository<Location, number> {
 			.eq('owner_id', userId)
 			.single();
 
-		if (locationOwner.owner_id) {
+		if (locationOwner?.owner_id) {
 			return true; // User is the owner, automatically has full permissions
 		}
 

--- a/src/routes/app/dashboard/location/[location_id]/Header.svelte
+++ b/src/routes/app/dashboard/location/[location_id]/Header.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import Button from '$lib/components/UI/buttons/Button.svelte';
+	import type { Location } from '$lib/models/Location';
+	import type { Snippet } from 'svelte';
+
+	type Props = {
+		location: Location;
+		basePath: string;
+		children?: Snippet;
+	};
+
+	let { location, basePath, children }: Props = $props();
+</script>
+
+<header
+	class="sticky top-0 z-9999 flex flex-col items-start justify-between gap-4 border-b border-gray-300 p-4 md:flex-row md:items-end dark:border-neutral-400"
+	style:background-color="var(--color-background)"
+>
+	<div class="flex-1">
+		<h1 class="text-2xl font-semibold text-gray-900 lg:text-3xl dark:text-gray-100">
+			{location.name}
+		</h1>
+		{#if location.description}
+			<p class="mt-2 text-sm text-gray-500 dark:text-gray-400">{location.description}</p>
+		{/if}
+	</div>
+	<div>
+		{#if children}
+			{@render children?.()}
+		{:else if basePath}
+			<Button variant="secondary" href={basePath}>« Back to Location Overview</Button>
+		{/if}
+	</div>
+</header>

--- a/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/+page.svelte
+++ b/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/+page.svelte
@@ -252,13 +252,13 @@
 	</div>
 </Header>
 
-<div class="flex flex-col gap-4 p-4 xl:flex-row">
+<div class="flex flex-col gap-4 p-4 lg:flex-row">
 	<!-- Left pane -->
 	<div
-		class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:flex xl:w-[320px] xl:grid-cols-1 xl:flex-col xl:gap-6"
+		class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:flex lg:w-[320px] lg:grid-cols-1 lg:flex-col lg:gap-6"
 	>
 		<!-- Latest data section -->
-		<section class="flex-auto lg:w-auto xl:flex-none">
+		<section class="flex-auto lg:w-auto lg:flex-none">
 			<h2>Latest Sensor Readings</h2>
 			{#if latestData}
 				<div>
@@ -367,7 +367,7 @@
 
 	<!-- Right pane -->
 	<div
-		class="relative flex-1 border-t-1 border-neutral-400 pt-4 xl:border-t-0 xl:pt-0"
+		class="relative flex-1 border-t-1 border-neutral-400 pt-4 lg:border-t-0 lg:pt-0"
 		inert={loadingHistoricalData}
 		aria-busy={loadingHistoricalData}
 	>

--- a/src/routes/app/dashboard/location/[location_id]/devices/create/+page.svelte
+++ b/src/routes/app/dashboard/location/[location_id]/devices/create/+page.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
-import { PermissionLevel } from '$lib/models/LocationUser.js';
-import { Button, Select } from 'bits-ui';
-import { formValidation } from '$lib/actions/formValidation';
+	import { page } from '$app/state';
+	import { formValidation } from '$lib/actions/formValidation';
+	import type { Location } from '$lib/models/Location';
+	import { PermissionLevel } from '$lib/models/LocationUser.js';
+	import { Button } from 'bits-ui';
+	import Header from '../../Header.svelte';
 
 	let { data } = $props();
 
-	const location = $derived(data.location);
+	const location = $derived(data.location as Location);
 	const users = $derived(data.usersInLocation);
 	const permissionTypes = data.permissionTypes; // Array<[label, level]>
 	const deviceTypes = data.deviceTypes; // Array<{ id: number, name: string }>
@@ -18,7 +21,8 @@ import { formValidation } from '$lib/actions/formValidation';
 	let userPermissions: Array<{ userId: string; level: number }> = $state([]);
 	let userPermissionsData = $state();
 	$effect(() => {
-		if (users) userPermissions = users.map(u => ({ userId: u.user_id, level: PermissionLevel.Disabled }));
+		if (users)
+			userPermissions = users.map((u) => ({ userId: u.user_id, level: PermissionLevel.Disabled }));
 	});
 
 	function updatePermission(index: number, level: number) {
@@ -26,7 +30,7 @@ import { formValidation } from '$lib/actions/formValidation';
 	}
 
 	function setAll(level: number) {
-		userPermissions = userPermissions.map(p => ({ ...p, level }));
+		userPermissions = userPermissions.map((p) => ({ ...p, level }));
 	}
 
 	$effect(() => {
@@ -34,14 +38,15 @@ import { formValidation } from '$lib/actions/formValidation';
 	});
 
 	let isSubmitting = false;
-
 </script>
 
 <svelte:head>
 	<title>Create a New Device</title>
 </svelte:head>
 
-<div class="flex flex-row gap-2">
+<Header {location} basePath={`/app/dashboard/location/${page.params.location_id}`} />
+
+<div class="m-4 flex flex-row gap-2">
 	<div class="flex flex-col gap-2">
 		<h1 class="text-2xl font-bold">Create a New Device</h1>
 		<p class="text-muted-foreground text-sm">
@@ -51,55 +56,84 @@ import { formValidation } from '$lib/actions/formValidation';
 </div>
 
 <form
-       id="create-device-form"
-       use:enhance
-       use:formValidation
-       action="?/createDevice"
-       method="POST"
-       class="form-container"
+	id="create-device-form"
+	use:enhance
+	use:formValidation
+	action="?/createDevice"
+	method="POST"
+	class="form-container m-4"
 >
 	<!-- Device information -->
 	<div class="flex flex-col gap-2">
 		<label for="deviceName" class="text-sm font-medium">Device Name</label>
-		<input name="deviceName" id="deviceName" type="text" required
-			class="rounded-input border-2 border-input bg-background placeholder:text-muted-foreground focus-visible:ring-ring h-12 px-3 text-sm" />
+		<input
+			name="deviceName"
+			id="deviceName"
+			type="text"
+			required
+			class="rounded-input border-input bg-background placeholder:text-muted-foreground focus-visible:ring-ring h-12 border-2 px-3 text-sm"
+		/>
 	</div>
 	<div class="flex flex-col gap-2">
 		<label for="devEui" class="text-sm font-medium">Dev EUI</label>
-		<input name="devEui" id="devEui" type="text" required
-			class="rounded-input border-2 border-input bg-background placeholder:text-muted-foreground focus-visible:ring-ring h-12 px-3 text-sm" />
+		<input
+			name="devEui"
+			id="devEui"
+			type="text"
+			required
+			class="rounded-input border-input bg-background placeholder:text-muted-foreground focus-visible:ring-ring h-12 border-2 px-3 text-sm"
+		/>
 	</div>
 	<div class="grid grid-cols-2 gap-4">
 		<div class="flex flex-col gap-2">
 			<label for="latitude" class="text-sm font-medium">Latitude</label>
-			<input name="latitude" id="latitude" type="number" step="any"
-				class="rounded-input border-2 border-input bg-background focus-visible:ring-ring h-12 px-3 text-sm" />
+			<input
+				name="latitude"
+				id="latitude"
+				type="number"
+				step="any"
+				class="rounded-input border-input bg-background focus-visible:ring-ring h-12 border-2 px-3 text-sm"
+			/>
 		</div>
 		<div class="flex flex-col gap-2">
 			<label for="longitude" class="text-sm font-medium">Longitude</label>
-			<input name="longitude" id="longitude" type="number" step="any"
-				class="rounded-input border-2 border-input bg-background focus-visible:ring-ring h-12 px-3 text-sm" />
+			<input
+				name="longitude"
+				id="longitude"
+				type="number"
+				step="any"
+				class="rounded-input border-input bg-background focus-visible:ring-ring h-12 border-2 px-3 text-sm"
+			/>
 		</div>
 	</div>
-	
+
 	<!-- Device Type selection -->
 	<div class="flex flex-col gap-2">
 		<label for="deviceType" class="text-sm font-medium">Device Type</label>
 		<div class="relative">
-			<select 
+			<select
 				id="deviceType"
-				name="deviceType" 
+				name="deviceType"
 				bind:value={selectedDeviceType}
-				class="rounded-input border-2 border-input bg-background h-12 w-full px-3 appearance-none cursor-pointer"
+				class="rounded-input border-input bg-background h-12 w-full cursor-pointer appearance-none border-2 px-3"
 			>
 				<option value={undefined}>Select a device type...</option>
 				{#each deviceTypes as deviceType}
 					<option value={deviceType.id}>{deviceType.name}</option>
 				{/each}
 			</select>
-			<div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-gray-500">
-				<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+			<div
+				class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3 text-gray-500"
+			>
+				<svg
+					class="h-4 w-4"
+					fill="none"
+					stroke="currentColor"
+					viewBox="0 0 24 24"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"
+					></path>
 				</svg>
 			</div>
 		</div>
@@ -107,17 +141,21 @@ import { formValidation } from '$lib/actions/formValidation';
 	<!-- User permissions -->
 	<div class="mt-4">
 		<h2 class="text-lg font-semibold">User Permissions</h2>
-		<div class="flex gap-2 my-2">
+		<div class="my-2 flex gap-2">
 			{#each permissionTypes as [label, level]}
-				<button type="button" class="px-3 py-1 bg-secondary text-background rounded" onclick={() => setAll(level)}>
+				<button
+					type="button"
+					class="bg-secondary text-background rounded px-3 py-1"
+					onclick={() => setAll(level)}
+				>
 					Set All {label}
 				</button>
 			{/each}
 		</div>
-		<table class="w-full text-sm border-collapse">
+		<table class="w-full border-collapse text-sm">
 			<thead>
 				<tr>
-					<th class="text-left p-2">User</th>
+					<th class="p-2 text-left">User</th>
 					{#each permissionTypes as [label]}
 						<th class="p-2">{label}</th>
 					{/each}
@@ -125,15 +163,17 @@ import { formValidation } from '$lib/actions/formValidation';
 			</thead>
 			<tbody>
 				{#each users as user, i}
-				<tr class="border-t">
-					<td class="p-2">{user.profile.email}</td>
-					{#each permissionTypes as [, level]}
-					<td class="p-2 text-center">
-								<input type="radio"
+					<tr class="border-t">
+						<td class="p-2">{user.profile.email}</td>
+						{#each permissionTypes as [, level]}
+							<td class="p-2 text-center">
+								<input
+									type="radio"
 									name="perm-{user.user_id}"
 									value={level}
 									checked={userPermissions[i]?.level === level}
-									onchange={() => updatePermission(i, level)} />
+									onchange={() => updatePermission(i, level)}
+								/>
 							</td>
 						{/each}
 					</tr>
@@ -144,12 +184,12 @@ import { formValidation } from '$lib/actions/formValidation';
 	</div>
 	<!-- Submit button -->
 	<div class="flex justify-end">
-       <Button.Root
-               type="submit"
-               form="create-device-form"
-               disabled={isSubmitting}
-               class="px-6 py-2 bg-primary text-white rounded"
-       >
+		<Button.Root
+			type="submit"
+			form="create-device-form"
+			disabled={isSubmitting}
+			class="bg-primary rounded px-6 py-2 text-white"
+		>
 			{isSubmitting ? 'Creating...' : 'Create Device'}
 		</Button.Root>
 	</div>

--- a/src/routes/app/dashboard/location/[location_id]/settings/+page.svelte
+++ b/src/routes/app/dashboard/location/[location_id]/settings/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-	import { browser } from '$app/environment';
 	import { enhance } from '$app/forms';
-	import { error as errorToast, success } from '$lib/stores/toast.svelte';
+	import { page } from '$app/state';
 	import { formValidation } from '$lib/actions/formValidation';
+	import { error as errorToast, success } from '$lib/stores/toast.svelte';
+	import Header from '../Header.svelte';
 
 	let { data } = $props();
 
@@ -165,15 +166,11 @@
 	<title>Location Settings - {locationName}</title>
 </svelte:head>
 
-<div class="container mx-auto px-4 py-8">
+<Header {location} basePath={`/app/dashboard/location/${page.params.location_id}`} />
+
+<div class="container mx-auto my-4">
 	<div class="mb-6 flex items-center justify-between">
-		<h1 class="text-2xl font-bold">Location Settings: {location.name}</h1>
-		<a
-			href="/app/dashboard/location/{location.location_id}/"
-			class="text-blue-500 hover:text-blue-700"
-		>
-			Back to Location
-		</a>
+		<h1 class="text-2xl font-bold">Location Settings</h1>
 	</div>
 
 	<!-- Location Details Section -->


### PR DESCRIPTION
Part of #237

- Update the design of the Location Details page
- Remove some verbose details like owner ID
- Change the viewport breakpoint on the Details page for consistency
- Add the same header to the Location Settings and Add Device
- Fix 500 internal error on the Location Settings page

Future suggestion: Having both location and device coordinates seems redundant. Maybe a location doesn’t need it. The Location Details page’s map could just display all the device coordinates.