### PR TITLE
Add vehicle count to calendar

### DIFF
--- a/src/lib/components/WeatherCalendar.svelte
+++ b/src/lib/components/WeatherCalendar.svelte
@@ -47,7 +47,6 @@
 					precipitation: entry.weather.totalprecip_mm
 				}
 			}));
-			mappedEvents.push(...events);
 			weather = mappedEvents;
 			console.log('Mapped weather events:', weather);
 		} catch (err) {
@@ -105,7 +104,7 @@
 	const options = $derived({
 		view: 'dayGridMonth',
 		date: currentDate, // Use tracked current date
-		events: weather.filter((event) => event && event.start), // Filter out invalid events
+		events: [...weather, ...events].filter((event) => event && event.start), // Filter out invalid events
 		eventContent: eventContentRenderer,
 		dayMaxEvents: true, // Allow +more link when too many events
 		height: '700px',


### PR DESCRIPTION
- Add the daily numbers of vehicles, bicycles and people to the calendar on the Device Details page
- Fix rendering of these additional data (it’s broken for temperature)