### PR TITLE
Further optimize device details for mobile

### DIFF
--- a/src/lib/components/GlobalSidebar.svelte
+++ b/src/lib/components/GlobalSidebar.svelte
@@ -114,7 +114,7 @@
 
 <!-- Sidebar -->
 <aside
-	class="fixed top-0 left-0 z-50 flex flex-col border-r transition-all duration-300 ease-in-out
+	class="fixed top-0 left-0 z-10000 flex flex-col border-r transition-all duration-300 ease-in-out
 		{getDarkMode() ? 'border-slate-700/30 bg-slate-800/95' : 'border-gray-200/30 bg-white/95'}
 		shadow-lg backdrop-blur-sm"
 	style="top: 73px; 

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -115,6 +115,8 @@
 		<!-- CTA Button -->
 		<span class="flex-1"></span>
 		<div class="hidden items-center gap-3 md:flex">
+			<!-- @todo Move the language and theme selectors to the user settings page -->
+			<LanguageSelector />
 			<ThemeToggle />
 			{#if page.data.session?.user}
 				<Button variant="secondary" onclick={handleLogout}>{$_('Logout')}</Button>
@@ -305,7 +307,6 @@
 				<Breadcrumbs />
 			</div>
 			<div class="flex-1"></div>
-			<LanguageSelector />
 			<!-- Quick actions -->
 			<div class="hidden items-center gap-4 text-sm md:flex">
 				<a

--- a/src/lib/components/UI/buttons/Button.svelte
+++ b/src/lib/components/UI/buttons/Button.svelte
@@ -32,7 +32,7 @@
 	const colors = {
 		primary: 'green',
 		secondary: 'gray',
-		tertiary: 'neutral',
+		tertiary: 'transparent',
 		danger: 'red',
 		ghost: 'transparent'
 	};
@@ -50,7 +50,7 @@
 <button
 	{type}
 	disabled={disabled == true || loading == true}
-	class="focus-visible:ring-ring bg-{color}-700 text-white hover:bg-{color}-700/90 active:bg-{color}-700/95 inline-flex cursor-pointer items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-semibold text-nowrap shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:cursor-default disabled:opacity-50 {variant} {className}"
+	class="focus-visible:ring-ring bg-{color}-700 text-white hover:bg-{color}-700/90 active:bg-{color}-700/95 inline-flex min-h-9 cursor-pointer items-center justify-center gap-2 rounded-md px-4 py-0 text-sm font-semibold text-nowrap shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:cursor-default disabled:opacity-50 {variant} {className}"
 	class:iconic
 	onclick={(event) => {
 		if (disabled) return;
@@ -77,12 +77,21 @@
 	@reference "tailwindcss";
 
 	button {
+		/* Same as text input */
+		&.tertiary {
+			@apply rounded border !border-gray-300 !bg-white !text-gray-900 text-inherit shadow-none;
+
+			:global(.dark) & {
+				@apply !border-zinc-700 !bg-zinc-800 !text-white;
+			}
+		}
+
 		&.ghost {
 			@apply text-inherit shadow-none;
 		}
 
 		&.iconic {
-			@apply !p-2;
+			@apply aspect-square !p-0;
 		}
 	}
 </style>

--- a/src/lib/components/UI/form/TextInput.svelte
+++ b/src/lib/components/UI/form/TextInput.svelte
@@ -25,6 +25,6 @@
 	bind:value
 	{placeholder}
 	{disabled}
-	class="rounded border border-gray-300 bg-white p-2 text-gray-900 text-inherit dark:border-zinc-700 dark:bg-zinc-800 dark:text-white {className}"
+	class="min-h-9 rounded border border-gray-300 bg-white px-2 py-0 text-gray-900 text-inherit dark:border-zinc-700 dark:bg-zinc-800 dark:text-white {className}"
 	{...rest}
 />

--- a/src/lib/components/dashboard/CameraStream.svelte
+++ b/src/lib/components/dashboard/CameraStream.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import type { DeviceWithType } from '$lib/models/Device';
+	import { _ } from 'svelte-i18n';
+
+	type Props = {
+		device?: DeviceWithType;
+		class?: string;
+	};
+
+	let { device, class: className = '' }: Props = $props();
+</script>
+
+{#if device?.ip_log.length}
+	<section class={className}>
+		<h2>{$_('Camera Stream')}</h2>
+		{#if device?.ip_log.length > 0}
+			{#each device.ip_log as log}
+				<img
+					class="sc-hHOBiw eJjIgh"
+					src="https://153.137.8.13:2223/mjpg/video.mjpg?camera=1&amp;audiocodec=aac&amp;audiosamplerate=16000&amp;audiobitrate=32000&amp;videozprofile=classic&amp;timestamp=0&amp;cachebust=1"
+					alt="Camera Stream"
+				/>
+			{/each}
+		{:else}
+			<p class="pt-4 text-center text-gray-500 italic">{$_('No stream available')}</p>
+		{/if}
+	</section>
+{/if}

--- a/src/lib/components/dashboard/DateRangeSelector.svelte
+++ b/src/lib/components/dashboard/DateRangeSelector.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import Button from '$lib/components/UI/buttons/Button.svelte';
+	import TextInput from '$lib/components/UI/form/TextInput.svelte';
+	import MaterialIcon from '$lib/components/UI/icons/MaterialIcon.svelte';
+	import { DateTime } from 'luxon';
+	import { _ } from 'svelte-i18n';
+
+	type Props = {
+		startDateInputString: string;
+		endDateInputString: string;
+		handleDateRangeSubmit: (units?: number) => void;
+		loadingHistoricalData: boolean;
+		error?: string;
+	};
+
+	let {
+		startDateInputString = $bindable(),
+		endDateInputString = $bindable(),
+		handleDateRangeSubmit,
+		loadingHistoricalData,
+		error
+	}: Props = $props();
+</script>
+
+<div class="flex flex-wrap items-end gap-2 sm:flex-row-reverse">
+	<!-- Date range selector -->
+	<div class="flex flex-wrap items-end gap-2">
+		<!-- Date inputs -->
+		<div class="flex flex-col sm:order-2">
+			<label for="startDate" class="mb-1 text-xs text-gray-600 dark:text-gray-400">
+				{$_('Start Date:')}
+			</label>
+			<TextInput
+				id="startDate"
+				type="date"
+				bind:value={startDateInputString}
+				max={endDateInputString}
+				class="text-sm"
+			/>
+		</div>
+		<div class="flex flex-col sm:order-3">
+			<label for="endDate" class="mb-1 text-xs text-gray-600 dark:text-gray-400">
+				{$_('End Date:')}
+			</label>
+			<TextInput
+				id="endDate"
+				type="date"
+				bind:value={endDateInputString}
+				min={startDateInputString}
+				max={new Date().toISOString().split('T')[0]}
+				class="text-sm"
+			/>
+		</div>
+		<div class="sm:order-5">
+			<Button
+				variant="tertiary"
+				iconic
+				onclick={() => handleDateRangeSubmit()}
+				disabled={loadingHistoricalData}
+			>
+				<MaterialIcon name="refresh" aria-label={$_('refresh')} />
+			</Button>
+		</div>
+		<div class="flex gap-2 sm:contents">
+			<div class="sm:order-1">
+				<Button variant="tertiary" iconic onclick={() => handleDateRangeSubmit(-1)}>
+					<MaterialIcon name="fast_rewind" />
+				</Button>
+			</div>
+			<div class="sm:order-4">
+				<Button
+					variant="tertiary"
+					iconic
+					disabled={new Date(endDateInputString) >= DateTime.now().minus({ days: 1 }).toJSDate()}
+					onclick={() => handleDateRangeSubmit(1)}
+				>
+					<MaterialIcon name="fast_forward" />
+				</Button>
+			</div>
+		</div>
+		{#if error}
+			<p class="mt-2 text-sm text-red-600">{'error'}</p>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/dashboard/DeviceMap.svelte
+++ b/src/lib/components/dashboard/DeviceMap.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import LeafletMap from '$lib/components/maps/leaflet/LeafletMap.svelte';
+	import type { DeviceWithType } from '$lib/models/Device';
+	import { _ } from 'svelte-i18n';
+
+	type Props = {
+		device?: DeviceWithType;
+		class?: string;
+	};
+
+	let { device, class: className = '' }: Props = $props();
+</script>
+
+{#if device}
+	<section class={className}>
+		<h2>{$_('Map')}</h2>
+		<div class="aspect-square">
+			<LeafletMap
+				lat={device.lat || 0}
+				lon={device.long || 0}
+				zoom={17}
+				markers={[[device.lat || 0, device.long || 0]]}
+			/>
+		</div>
+	</section>
+{/if}

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -175,12 +175,6 @@ export const strings = {
 	'Camera Stream': 'Camera Stream',
 	'No stream available': 'No stream available',
 	Map: 'Map',
-	'Device Info': 'Device Info',
-	'Type:': 'Type:',
-	'EUI:': 'EUI:',
-	'Location ID:': 'Location ID:',
-	'Installed:': 'Installed:',
-	'Sensor Datasheet': 'Sensor Datasheet',
 	'Last updated:': 'Last updated:',
 	'Stats Summary': 'Stats Summary',
 	'Data Chart': 'Data Chart',
@@ -317,6 +311,10 @@ export const strings = {
 	Recipients: 'Recipients',
 
 	// Settings page
+	Unknown: 'Unknown',
+	EUI: 'EUI',
+	'Installed Date': 'Installed Date',
+	'Device Location': 'Device Location',
 	'Units & Display Settings': 'Units & Display Settings',
 
 	// Error pages

--- a/src/lib/i18n/locales/ja.ts
+++ b/src/lib/i18n/locales/ja.ts
@@ -215,12 +215,6 @@ export const strings = {
 	'Camera Stream': 'カメラストリーム',
 	'No stream available': 'ストリームは利用できません',
 	Map: '地図',
-	'Device Info': 'デバイス情報',
-	'Type:': 'タイプ:',
-	'EUI:': 'EUI:',
-	'Location ID': 'ロケーションID',
-	'Installed:': '設置日:',
-	'Sensor Datasheet': 'センサーデータシート',
 	'Last updated:': '最終更新:',
 	'Stats Summary': '統計概要',
 	'Data Chart': 'データチャート',
@@ -368,6 +362,10 @@ export const strings = {
 	'Collapse sidebar': 'サイドバーを折りたたむ',
 
 	// Settings page
+	Unknown: '不明',
+	EUI: 'EUI',
+	'Installed Date': '設置日',
+	'Device Location': 'デバイスの場所',
 	'Units & Display Settings': '単位と表示設定',
 
 	// Error page

--- a/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/+page.svelte
+++ b/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/+page.svelte
@@ -1,30 +1,29 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import CameraStream from '$lib/components/dashboard/CameraStream.svelte';
+	import DateRangeSelector from '$lib/components/dashboard/DateRangeSelector.svelte';
+	import DeviceMap from '$lib/components/dashboard/DeviceMap.svelte';
 	import DataCard from '$lib/components/DataCard/DataCard.svelte';
-	import LeafletMap from '$lib/components/maps/leaflet/LeafletMap.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
 	import StatsCard from '$lib/components/StatsCard/StatsCard.svelte';
 	import Button from '$lib/components/UI/buttons/Button.svelte';
-	import TextInput from '$lib/components/UI/form/TextInput.svelte';
-	import MaterialIcon from '$lib/components/UI/icons/MaterialIcon.svelte';
 	import WeatherCalendar from '$lib/components/WeatherCalendar.svelte';
+	import CsvDownloadButton from '$lib/csv/CsvDownloadButton.svelte';
 	import type { DeviceWithType } from '$lib/models/Device';
 	import type { DeviceDataRecord } from '$lib/models/DeviceDataRecord';
 	import {
 		formatDateForInput,
-		formatDateOnly,
 		formatDateForDisplay as utilFormatDateForDisplay
 	} from '$lib/utilities/helpers';
 	import { formatNumber } from '$lib/utilities/stats';
-	import { onMount } from 'svelte';
+	import type { RealtimeChannel } from '@supabase/supabase-js';
+	import { DateTime } from 'luxon';
+	import { onMount, untrack } from 'svelte';
 	import { _, locale } from 'svelte-i18n';
 	import type { PageProps } from './$types';
 	import { getDeviceDetailDerived, setupDeviceDetail } from './device-detail.svelte';
 	import Header from './Header.svelte';
-	import CsvDownloadButton from '$lib/csv/CsvDownloadButton.svelte';
 	import { setupRealtimeSubscription } from './realtime.svelte';
-	import type { RealtimeChannel } from '@supabase/supabase-js';
-	import { DateTime } from 'luxon';
 
 	// Get device data from server load function
 	let { data }: PageProps = $props();
@@ -46,6 +45,7 @@
 		display: string;
 	}
 
+	let numericKeys: string[] = $state([]); // Holds numeric keys from historical data
 	let calendarEvents = $state<CalendarEvent[]>([]);
 
 	// Setup device detail functionality
@@ -58,6 +58,7 @@
 		loading, // Bound to deviceDetail.loading
 		error, // Bound to deviceDetail.error
 		processHistoricalData,
+		getNumericKeys,
 		fetchDataForDateRange, // This is deviceDetail.fetchDataForDateRange
 		renderVisualization, // This is deviceDetail.renderVisualization
 		initializeDateRange // This is deviceDetail.initializeDateRange
@@ -65,15 +66,15 @@
 	} = deviceDetail;
 
 	// DOM element references
-	let chart1: HTMLElement | undefined = $state();
-	let chart1Brush: HTMLElement | undefined = $state();
+	let mainChartElements: HTMLElement[] = $state([]); // Holds chart elements for rendering
+	let blushChartElements: HTMLElement[] = $state([]); // Holds brush elements for rendering
 
 	// Local string states for date inputs, bound to the input fields
 	let startDateInputString = $state('');
 	let endDateInputString = $state('');
 
-	let loadingHistoricalData = $state(true); // Local loading state for historical data fetch
-	let renderingVisualization = $state(true); // Local rendering state for visualization
+	let loadingHistoricalData = $state(false); // Local loading state for historical data fetch
+	let renderingVisualization = $state(false); // Local rendering state for visualization
 
 	// Derived properties
 	const {
@@ -117,29 +118,50 @@
 	$effect(() => {
 		(async () => {
 			loadingHistoricalData = true;
-			historicalData = await data.historicalData;
-			processHistoricalData(historicalData); // Initial processing of server-loaded data
+
+			const _historicalData = await data.historicalData;
+
+			processHistoricalData(_historicalData); // Initial processing of server-loaded data
+			historicalData = _historicalData; // Set historical data state
+			numericKeys = getNumericKeys(historicalData);
 			calendarEvents = updateEvents(); // Initialize calendar events based on historical data
 			loadingHistoricalData = false;
 		})();
 	});
 
 	const renderChart = async () => {
+		if (renderingVisualization || !numericKeys.length) {
+			return;
+		}
+
 		renderingVisualization = true;
-		await renderVisualization(historicalData, dataType, latestData, chart1, chart1Brush);
+
+		await Promise.all(
+			numericKeys.map((key, index) =>
+				renderVisualization({
+					historicalData,
+					chart1Element: mainChartElements[index],
+					chart1BrushElement: blushChartElements[index],
+					key
+				})
+			)
+		);
+
 		renderingVisualization = false;
 	};
 
-	// Re-render chart when historical data or DOM elements change
+	// Re-render chart when historical data changes
 	$effect(() => {
-		void [historicalData, dataType, latestData, chart1, chart1Brush];
-		renderChart();
+		void [$locale, historicalData];
+
+		untrack(() => {
+			renderChart();
+		});
 	});
 
 	// Re-render chart and calendar when the app locale changes, because the labels depend on it
 	$effect(() => {
 		void $locale;
-		renderChart();
 		calendarEvents = updateEvents(historicalData);
 	});
 
@@ -276,77 +298,23 @@
 </svelte:head>
 
 <Header {device} {basePath}>
-	{#snippet controls()}
+	<div class="flex w-full justify-end gap-2 md:w-auto">
 		<CsvDownloadButton {devEui} />
-		<Button class="invisible" variant="secondary" href="{basePath}/settings">{$_('report')}</Button>
+		<Button class="!hidden" variant="secondary" href="{basePath}/settings">{$_('report')}</Button>
 		<Button variant="secondary" href="{basePath}/settings">{$_('settings')}</Button>
-	{/snippet}
-	<div class="flex flex-wrap items-end gap-4 sm:flex-row-reverse">
-		<!-- Date range selector -->
-		<div class="flex flex-wrap items-end gap-2">
-			<!-- Date inputs -->
-			<div class="flex flex-col">
-				<label for="startDate" class="mb-1 text-xs text-gray-600 dark:text-gray-400">
-					{$_('Start Date:')}
-				</label>
-				<div class="gap=0 flex flex-row">
-					<Button
-						variant="ghost"
-						class="p-0!important m-0 max-w-6 rounded border border-gray-300"
-						onclick={() => handleDateRangeSubmit(-1)}
-					>
-						<MaterialIcon name="fast_rewind" size="small" />
-					</Button>
-					<TextInput
-						id="startDate"
-						type="date"
-						bind:value={startDateInputString}
-						max={endDateInputString}
-						class="text-sm"
-					/>
-				</div>
-			</div>
-			<div class="flex flex-col">
-				<label for="endDate" class="mb-1 text-xs text-gray-600 dark:text-gray-400">
-					{$_('End Date:')}
-				</label>
-				<div class="gap=0 flex flex-row">
-					<TextInput
-						id="endDate"
-						type="date"
-						bind:value={endDateInputString}
-						min={startDateInputString}
-						max={new Date().toISOString().split('T')[0]}
-						class="text-sm"
-					/>
-					<Button
-						disabled={new Date(endDateInputString) >= DateTime.now().minus({ days: 1 }).toJSDate()}
-						variant="ghost"
-						class="p-0!important m-0 max-w-6 rounded border border-gray-300"
-						onclick={() => handleDateRangeSubmit(1)}
-					>
-						<MaterialIcon name="fast_forward" size="small" />
-					</Button>
-				</div>
-			</div>
-			<div class="-ml-2">
-				<Button
-					variant="ghost"
-					iconic
-					onclick={handleDateRangeSubmit}
-					disabled={loadingHistoricalData}
-				>
-					<MaterialIcon name="refresh" aria-label={$_('refresh')} />
-				</Button>
-			</div>
-			{#if error}
-				<p class="mt-2 text-sm text-red-600">{'error'}</p>
-			{/if}
-		</div>
+	</div>
+	<!-- Data range selector on large screen -->
+	<div class="hidden border-l border-neutral-400 pl-4 lg:block">
+		<DateRangeSelector
+			{startDateInputString}
+			{endDateInputString}
+			{handleDateRangeSubmit}
+			{loadingHistoricalData}
+		/>
 	</div>
 </Header>
 
-<div class="flex flex-col gap-4 p-4 lg:flex-row">
+<div class="wrapper flex flex-col gap-4 p-4 lg:flex-row">
 	<!-- Left pane -->
 	<div
 		class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:flex lg:w-[320px] lg:grid-cols-1 lg:flex-col lg:gap-6"
@@ -380,84 +348,9 @@
 			{/if}
 		</section>
 
-		<!-- Video Feed is IP is there -->
-		<section class="flex-none {device?.ip_log.length > 0 ? 'visible' : 'invisible'}">
-			<h2>{$_('Camera Stream')}</h2>
-			{#if device?.ip_log.length > 0}
-				{#each device.ip_log as log}
-					<img
-						class="sc-hHOBiw eJjIgh"
-						src="https://153.137.8.13:2223/mjpg/video.mjpg?camera=1&amp;audiocodec=aac&amp;audiosamplerate=16000&amp;audiobitrate=32000&amp;videozprofile=classic&amp;timestamp=0&amp;cachebust=1"
-						alt="Camera Stream"
-					/>
-				{/each}
-			{:else}
-				<p class="pt-4 text-center text-gray-500 italic">{$_('No stream available')}</p>
-			{/if}
-		</section>
-
-		{#if device}
-			<section class="flex-none">
-				<h2>{$_('Map')}</h2>
-				<div class="aspect-square">
-					<LeafletMap
-						lat={device.lat || 0}
-						lon={device.long || 0}
-						zoom={17}
-						markers={[[device.lat || 0, device.long || 0]]}
-					/>
-				</div>
-			</section>
-		{/if}
-
-		<!-- Device metadata container -->
-		<section class="flex-none">
-			<h2>{$_('Device Info')}</h2>
-			<div class="rounded-lg bg-gray-50 p-4 shadow-sm dark:bg-zinc-800">
-				<!-- Responsive: 1 col on mobile, 2 on md, 4 on lg -->
-				<div class="grid grid-rows-1 gap-2 text-sm">
-					<!-- Type -->
-					<div>
-						<span class="text-gray-500/80 dark:text-gray-300/80">{$_('Type:')}</span>
-						<span class="ml-1 break-words text-gray-900 dark:text-white">{deviceTypeName}</span>
-					</div>
-
-					<!-- EUI -->
-					<div>
-						<span class="text-gray-500/80 dark:text-gray-300/80">{$_('EUI:')}</span>
-						<span class="ml-1 break-words text-gray-900 dark:text-white">{device.dev_eui}</span>
-					</div>
-
-					<!-- Location ID -->
-					{#if device?.location_id}
-						<div>
-							<span class="text-gray-500/80 dark:text-gray-300/80">{$_('Location ID:')}</span>
-							<span class="ml-1 text-gray-900 dark:text-white">{device.location_id}</span>
-						</div>
-					{/if}
-
-					<!-- Installed At -->
-					{#if device?.installed_at}
-						<div>
-							<span class="text-gray-500/80 dark:text-gray-300/80">{$_('Installed:')}</span>
-							<span class="ml-1 text-gray-900 dark:text-white">
-								{formatDateOnly(device.installed_at)}
-							</span>
-						</div>
-					{/if}
-
-					<div>
-						<a
-							href="https://kb.cropwatch.io/doku.php?id=co2_sensors"
-							target="_blank"
-							class="text-gray-500/80 dark:text-gray-300/80"
-						>
-							{$_('Sensor Datasheet')}
-						</a>
-					</div>
-				</div>
-			</div>
-		</section>
+		<!-- Video feed and map on large screen -->
+		<CameraStream {device} class="hidden flex-none lg:block" />
+		<DeviceMap {device} class="hidden flex-none lg:block" />
 	</div>
 
 	<!-- Right pane -->
@@ -475,6 +368,15 @@
 				{$_('Loading historical data...')}
 			</div>
 		{/if}
+		<!-- Data range selector on small/medium screen -->
+		<div class="mb-4 border-b border-neutral-400 pb-4 lg:hidden">
+			<DateRangeSelector
+				{startDateInputString}
+				{endDateInputString}
+				{handleDateRangeSubmit}
+				{loadingHistoricalData}
+			/>
+		</div>
 		<section class="mb-12">
 			{#if loading}
 				<!-- Loading State -->
@@ -524,24 +426,28 @@
 								Rendering chart...
 							</div>
 						{/if}
-						<h4
-							class="mb-4 text-center text-base text-xl font-medium text-gray-800 dark:text-gray-200"
-							hidden={renderingVisualization}
-						>
-							{$_('All Sensor Data Over Time')}
-						</h4>
 						<div class="w-full">
-							<div class="chart-placeholder">
-								<div class="chart-visual">
-									<div class="chart main-chart" bind:this={chart1}></div>
-									<div class="chart brush-chart" bind:this={chart1Brush}></div>
-								</div>
+							<div class="chart-placeholder grid grid-cols-1 gap-4 md:grid-cols-2">
+								{#each numericKeys as key, index (key)}
+									<section class="chart-visual">
+										<h3 class="text-center font-semibold">{$_(key)}</h3>
+										<div class="chart main-chart" bind:this={mainChartElements[index]}></div>
+										<div class="chart brush-chart" bind:this={blushChartElements[index]}></div>
+									</section>
+								{/each}
 							</div>
 						</div>
 					</div>
 				</section>
 			{/if}
 		</section>
+
+		<!-- Video feed and map on small/medium screen -->
+		<div class="grid grid-cols-1 md:grid-cols-2 lg:hidden">
+			<CameraStream {device} />
+			<DeviceMap {device} />
+		</div>
+
 		<div class="mt-4">
 			<section>
 				<h2>{$_('Weather & Data')}</h2>
@@ -579,12 +485,11 @@
 
 		/* These classes are critical for ApexCharts rendering size */
 		.main-chart {
-			height: 350px;
+			height: 200px;
 		}
 
 		.brush-chart {
-			height: 150px;
-			margin-top: 10px;
+			height: 100px;
 		}
 
 		:global {
@@ -627,22 +532,15 @@
 		font-size: 12px !important;
 	} */
 
-	/* Responsive layout for mobile */
-	@media (max-width: 768px) {
-		.chart-visual .main-chart {
-			height: 300px;
-		}
+	.wrapper {
+		:global {
+			h2 {
+				@apply mb-2 text-xl font-semibold text-gray-600;
 
-		.chart-visual .brush-chart {
-			height: 120px;
-		}
-	}
-
-	h2 {
-		@apply mb-2 text-xl font-semibold text-gray-600;
-
-		:global(.dark) & {
-			@apply text-gray-300;
+				:global(.dark) & {
+					@apply text-gray-300;
+				}
+			}
 		}
 	}
 </style>

--- a/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/Header.svelte
+++ b/src/routes/app/dashboard/location/[location_id]/devices/[devEui]/Header.svelte
@@ -8,10 +8,9 @@
 		device: DeviceWithType;
 		basePath: string;
 		children?: Snippet;
-		controls?: Snippet;
 	};
 
-	let { device, basePath, children, controls }: Props = $props();
+	let { device, basePath, children }: Props = $props();
 </script>
 
 <header
@@ -22,7 +21,6 @@
 		<div class="w-full text-2xl font-semibold text-gray-900 lg:text-3xl dark:text-gray-100">
 			{device.name}
 		</div>
-		<div class="flex w-full justify-end">{@render controls?.()}</div>
 	</h1>
 	{#if children}
 		{@render children?.()}


### PR DESCRIPTION
- Change the order of the sections, moving the camera stream and map below the chart on mobile
- Move the date range selector below the latest readings on mobile
- Move the device details to the device settings page
- Create a chart for each sensor metric because the combined chart looks poor especially on mobile, and most of the metrics seem uncorrelated
  - What do you think?
  - Some metrics may be grouped if needed if they are correlated
- Move the language selector to the header
  - but it should be eventually moved to the user settings page
- Tweak the styles